### PR TITLE
[김진영] Add : 보관함 UI 구현 및 shuffle 로직 수정

### DIFF
--- a/src/components/playbar/Playbar.js
+++ b/src/components/playbar/Playbar.js
@@ -296,14 +296,16 @@ const Playbar = ({
           />
         )}
 
-        <BiShuffle
-          size="35.1"
-          className="shuffle"
-          onClick={() => {
-            const randomTracks = musicTracks.sort(() => Math.random() - 0.5);
-            setMusicTracks([...randomTracks]);
-          }}
-        />
+        {isExpandedClicked || (
+          <BiShuffle
+            size="35.1"
+            className="shuffle"
+            onClick={() => {
+              const randomTracks = musicTracks.sort(() => Math.random() - 0.5);
+              setMusicTracks([...randomTracks]);
+            }}
+          />
+        )}
 
         {!isExpandedClicked || (
           <PlayList

--- a/src/components/playbar/Playbar.js
+++ b/src/components/playbar/Playbar.js
@@ -271,10 +271,19 @@ const Playbar = ({
                 size="35.1"
                 className="expanded-shuffle"
                 onClick={() => {
-                  const randomTracks = musicTracks.sort(
+                  const randomTracks = [...musicTracks].sort(
                     () => Math.random() - 0.5
                   );
-                  setMusicTracks([...randomTracks]);
+                  if (randomTracks[0] === musicTracks[0]) {
+                    let lastIndex = randomTracks.length - 1;
+                    let randomValue = Math.floor(
+                      Math.random() * (lastIndex - 1) + 1
+                    );
+                    const temp = randomTracks[0];
+                    randomTracks[0] = randomTracks[lastIndex];
+                    randomTracks[lastIndex] = temp;
+                  }
+                  setMusicTracks(randomTracks);
                 }}
               />
             )}
@@ -301,8 +310,19 @@ const Playbar = ({
             size="35.1"
             className="shuffle"
             onClick={() => {
-              const randomTracks = musicTracks.sort(() => Math.random() - 0.5);
-              setMusicTracks([...randomTracks]);
+              const randomTracks = [...musicTracks].sort(
+                () => Math.random() - 0.5
+              );
+              if (randomTracks[0] === musicTracks[0]) {
+                let lastIndex = randomTracks.length - 1;
+                let randomValue = Math.floor(
+                  Math.random() * (lastIndex - 1) + 1
+                );
+                const temp = randomTracks[0];
+                randomTracks[0] = randomTracks[lastIndex];
+                randomTracks[lastIndex] = temp;
+              }
+              setMusicTracks(randomTracks);
             }}
           />
         )}

--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -63,7 +63,15 @@ function Router() {
         <Route path="/" element={<Main />} />
         <Route path="/detail" element={<Detail />} />
         <Route path="/storage" element={<Storage />}>
-          <Route path="mylist" element={<MyList />} />
+          <Route
+            path="mylist"
+            element={
+              <MyList
+                musicTracks={musicTracks}
+                setMusicTracks={setMusicTracks}
+              />
+            }
+          />
           <Route path="liketrack" element={<LikeTrack />} />
           <Route path="mostlisten" element={<MostListen />} />
           <Route path="recentlylisten" element={<RecentlyListen />} />

--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -17,6 +17,8 @@ import { Addtab, Browsemenu } from "../components/Browsemenu";
 import Genre from "../components/Genre";
 import Main from "./main/Main";
 import Detail from "../components/Detail";
+import Storage from "./storage/Storage";
+import MyList from "./storage/MyList";
 
 function Router() {
   const [trackIndex, setTrackIndex] = useState(0); // 현재 재생되고있는 음악 인덱스
@@ -30,7 +32,6 @@ function Router() {
 
   // musicTracks에 변화가 있을 때, 세션스토리지 값 변경 및 TrackIndex 0으로 설정
   useEffect(() => {
-    console.log("바뀜!");
     sessionStorage.setItem("tracks", JSON.stringify(musicTracks));
     if (musicTracks.length !== 0) setTrackIndex(0);
   }, [musicTracks]);
@@ -58,6 +59,9 @@ function Router() {
         </Route>
         <Route path="/" element={<Main />} />
         <Route path="/detail" element={<Detail />} />
+        <Route path="/storage" element={<Storage />}>
+          <Route path="mylist" element={<MyList />}></Route>
+        </Route>
       </Routes>
       <Footer />
       <Playbar

--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -19,6 +19,9 @@ import Main from "./main/Main";
 import Detail from "../components/Detail";
 import Storage from "./storage/Storage";
 import MyList from "./storage/MyList";
+import LikeTrack from "./storage/LikeTrack";
+import MostListen from "./storage/MostListen";
+import RecentlyListen from "./storage/RecentlyListen";
 
 function Router() {
   const [trackIndex, setTrackIndex] = useState(0); // 현재 재생되고있는 음악 인덱스
@@ -60,7 +63,10 @@ function Router() {
         <Route path="/" element={<Main />} />
         <Route path="/detail" element={<Detail />} />
         <Route path="/storage" element={<Storage />}>
-          <Route path="mylist" element={<MyList />}></Route>
+          <Route path="mylist" element={<MyList />} />
+          <Route path="liketrack" element={<LikeTrack />} />
+          <Route path="mostlisten" element={<MostListen />} />
+          <Route path="recentlylisten" element={<RecentlyListen />} />
         </Route>
       </Routes>
       <Footer />

--- a/src/pages/storage/LikeTrack.js
+++ b/src/pages/storage/LikeTrack.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const StyledLikeTrack = styled.div`
+  .my-list-inner-box {
+    width: 1280px;
+  }
+`;
+
+const LikeTrack = () => {
+  return (
+    <StyledLikeTrack>
+      <div className="my-list-inner-box"></div>
+    </StyledLikeTrack>
+  );
+};
+
+export default LikeTrack;

--- a/src/pages/storage/MostListen.js
+++ b/src/pages/storage/MostListen.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const StyledMostListen = styled.div`
+  .my-list-inner-box {
+    width: 1280px;
+  }
+`;
+
+const MostListen = () => {
+  return (
+    <StyledMostListen>
+      <div className="my-list-inner-box"></div>
+    </StyledMostListen>
+  );
+};
+
+export default MostListen;

--- a/src/pages/storage/MyList.js
+++ b/src/pages/storage/MyList.js
@@ -89,12 +89,17 @@ const StyledMyList = styled.div`
   }
 `;
 
-const MyList = () => {
+const MyList = ({ musicTracks, setMusicTracks }) => {
   return (
     <StyledMyList>
       <div className="my-list-inner-box">
         {mockData.data.map((el, i) => (
-          <PlayListContainer key={el.playlistId} data={el} />
+          <PlayListContainer
+            key={el.playlistId}
+            data={el}
+            musicTracks={musicTracks}
+            setMusicTracks={setMusicTracks}
+          />
         ))}
         <div className="play-list-container">
           <div className="play-list-cover">
@@ -113,14 +118,27 @@ const MyList = () => {
   );
 };
 
-const PlayListContainer = ({ data }) => {
+const PlayListContainer = ({ data, musicTracks, setMusicTracks }) => {
   return (
     <div className="play-list-container">
       <div className="play-list-cover">
         <div className="first-box" />
         <div className="second-box" />
         <img src={data.albumImage} className="third-box" />
-        <FaPlay className="play" />
+        <FaPlay
+          className="play"
+          onClick={() => {
+            fetch("http://localhost:3000/datas/music-track-data.json")
+              .then((res) => res.json())
+              .then((plData) => {
+                const musicTracksId = musicTracks.map((el) => el.id);
+                const filteredNewTracks = plData.filter(
+                  (el, i) => musicTracksId.includes(el.id) === false
+                );
+                setMusicTracks([...filteredNewTracks, ...musicTracks]);
+              });
+          }}
+        />
       </div>
       <div className="song-info">
         <h2 className="title">{data.title}</h2>

--- a/src/pages/storage/MyList.js
+++ b/src/pages/storage/MyList.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const StyledMyList = styled.div`
+  .my-list-inner-box {
+    width: 1280px;
+  }
+`;
+
+const MyList = () => {
+  return (
+    <StyledMyList>
+      <div className="my-list-inner-box"></div>
+    </StyledMyList>
+  );
+};
+
+export default MyList;

--- a/src/pages/storage/MyList.js
+++ b/src/pages/storage/MyList.js
@@ -1,17 +1,175 @@
 import styled from "styled-components";
+import { AiOutlinePlus } from "react-icons/ai";
+import { FaPlay } from "react-icons/fa";
 
 const StyledMyList = styled.div`
   .my-list-inner-box {
-    width: 1280px;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 80px 0 60px 0;
+
+    .play-list-container {
+      display: flex;
+      width: 470px;
+      margin-right: 20px;
+      margin-bottom: 20px;
+      /* background-color: #777777; */
+
+      .play-list-cover {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        cursor: pointer;
+
+        .first-box {
+          width: 170px;
+          height: 170px;
+          border-radius: 5px;
+          background-color: #f3f3f3;
+        }
+
+        .second-box {
+          width: 185px;
+          height: 185px;
+          margin-top: -167px;
+          border-radius: 5px;
+          background-color: #e9e9e9;
+        }
+
+        .third-box {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 200px;
+          height: 200px;
+          margin-top: -179px;
+          border-radius: 5px;
+          background-color: #dfdfdf;
+          color: #3f3fff;
+        }
+
+        .play {
+          position: absolute;
+          bottom: 25px;
+          right: 22.5px;
+          color: white;
+          transform: scale(1.75);
+          cursor: pointer;
+        }
+      }
+
+      .song-info {
+        margin: 30px 20px;
+
+        .title {
+          font-size: 20px;
+          font-weight: 700;
+          cursor: pointer;
+        }
+
+        .quantity {
+          margin: 25px 0 10px 0;
+          font-size: 14px;
+        }
+
+        .date {
+          font-size: 14px;
+          color: #969696;
+        }
+
+        .add-list {
+          margin-top: 70px;
+          color: #3f3fff;
+          font-weight: 700;
+          cursor: pointer;
+        }
+      }
+    }
   }
 `;
 
 const MyList = () => {
   return (
     <StyledMyList>
-      <div className="my-list-inner-box"></div>
+      <div className="my-list-inner-box">
+        {mockData.data.map((el, i) => (
+          <PlayListContainer key={el.playlistId} data={el} />
+        ))}
+        <div className="play-list-container">
+          <div className="play-list-cover">
+            <div className="first-box" />
+            <div className="second-box" />
+            <div className="third-box">
+              <AiOutlinePlus size="50" />
+            </div>
+          </div>
+          <div className="song-info">
+            <div className="add-list">새로운 리스트 만들기</div>
+          </div>
+        </div>
+      </div>
     </StyledMyList>
   );
 };
 
+const PlayListContainer = ({ data }) => {
+  return (
+    <div className="play-list-container">
+      <div className="play-list-cover">
+        <div className="first-box" />
+        <div className="second-box" />
+        <img src={data.albumImage} className="third-box" />
+        <FaPlay className="play" />
+      </div>
+      <div className="song-info">
+        <h2 className="title">{data.title}</h2>
+        <div className="quantity">총 {data.songTotalCount} 곡</div>
+        <div className="date">{data.createdAt}</div>
+      </div>
+    </div>
+  );
+};
+
 export default MyList;
+
+const mockData = {
+  data: [
+    {
+      userId: 1,
+      playlistId: 1,
+      title: "가을을 기다리는 발라드",
+      songTotalCount: "16",
+      albumImage:
+        "https://images.unsplash.com/photo-1641423914598-288fee6cecf2?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
+      createdAt: "2022.09.24",
+    },
+    {
+      userId: 1,
+      playlistId: 2,
+      title: "가사에 조용히 귀 기울여 듣는 발라드",
+      songTotalCount: "17",
+      albumImage:
+        "https://images.unsplash.com/photo-1587468820439-4c80fa8ec7c6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
+      createdAt: "2022.09.24",
+    },
+    {
+      userId: 1,
+      playlistId: 3,
+      title: "가을과 어울리는 편안한 감성 모음",
+      songTotalCount: "14",
+      albumImage:
+        "https://images.unsplash.com/photo-1611001440648-e90aff42faa3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
+      createdAt: "2022.09.24",
+    },
+    {
+      userId: 1,
+      playlistId: 12,
+      title: "요리하면서 듣기 좋은 맛있는 노래 모음",
+      songTotalCount: "9",
+      albumImage:
+        "https://images.unsplash.com/photo-1611001440648-e90aff42faa3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80",
+      createdAt: "2022.09.24",
+    },
+  ],
+};

--- a/src/pages/storage/MyList.js
+++ b/src/pages/storage/MyList.js
@@ -10,7 +10,7 @@ const StyledMyList = styled.div`
 
     .play-list-container {
       display: flex;
-      width: 470px;
+      width: 480px;
       margin-right: 20px;
       margin-bottom: 20px;
       /* background-color: #777777; */
@@ -32,7 +32,7 @@ const StyledMyList = styled.div`
         .second-box {
           width: 185px;
           height: 185px;
-          margin-top: -167px;
+          margin-top: -165px;
           border-radius: 5px;
           background-color: #e9e9e9;
         }
@@ -43,7 +43,7 @@ const StyledMyList = styled.div`
           justify-content: center;
           width: 200px;
           height: 200px;
-          margin-top: -179px;
+          margin-top: -180px;
           border-radius: 5px;
           background-color: #dfdfdf;
           color: #3f3fff;

--- a/src/pages/storage/RecentlyListen.js
+++ b/src/pages/storage/RecentlyListen.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const StyledRecentlyListen = styled.div`
+  .my-list-inner-box {
+    width: 1280px;
+  }
+`;
+
+const RecentlyListen = () => {
+  return (
+    <StyledRecentlyListen>
+      <div className="my-list-inner-box"></div>
+    </StyledRecentlyListen>
+  );
+};
+
+export default RecentlyListen;

--- a/src/pages/storage/Storage.js
+++ b/src/pages/storage/Storage.js
@@ -58,6 +58,7 @@ const Storage = () => {
   const [isLikedClicked, setIsLikedClicked] = useState(false);
   const [isMostListenClicked, setIsMostListenClicked] = useState(false);
   const [isRecentlyListenClicked, setIsRecentlyListenClicked] = useState(false);
+
   return (
     <StyledStorage>
       <div className="storage-inner-box">

--- a/src/pages/storage/Storage.js
+++ b/src/pages/storage/Storage.js
@@ -5,40 +5,120 @@ import { HiOutlineHeart, HiHeart } from "react-icons/hi"; // player like
 
 const StyledStorage = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex;
   justify-content: center;
-  padding-top: 150px;
-  font-family: "NanumBarunGothic", sans-serif;
 
-  .menu-list {
-    display: flex;
-    align-items: center;
-    border-bottom: 1.5px solid #eeeeee;
+  .storage-inner-box {
+    padding-top: 150px;
+    font-family: "NanumBarunGothic", sans-serif;
+    width: 1280px;
 
-    .list {
+    .menu-list {
       display: flex;
       align-items: center;
-      padding: 10px;
+      height: 38px;
+      border-bottom: 1.5px solid #eeeeee;
 
-      .icon {
-        margin-right: 3px;
+      .selected-list {
+        display: flex;
+        align-items: center;
+        height: 40px;
+        padding: 10px;
+        color: #3f3fff;
+        border-bottom: 2px solid #3f3fff;
+        font-weight: 700;
+        cursor: pointer;
+
+        .icon {
+          margin-right: 2px;
+        }
+      }
+
+      .list {
+        display: flex;
+        align-items: center;
+        height: 40px;
+        margin: 0 10px;
+        cursor: pointer;
+
+        &:hover {
+          color: #3f3fff;
+        }
+
+        .icon {
+          margin-right: 2px;
+        }
       }
     }
   }
 `;
 
 const Storage = () => {
+  const [isMyListClicked, setIsMyListClicked] = useState(true);
+  const [isLikedClicked, setIsLikedClicked] = useState(false);
+  const [isMostListenClicked, setIsMostListenClicked] = useState(false);
+  const [isRecentlyListenClicked, setIsRecentlyListenClicked] = useState(false);
   return (
     <StyledStorage>
       <div className="storage-inner-box">
         <ul className="menu-list">
-          <li className={"list"}>내 리스트</li>
-          <li className={"list"}>
-            <HiOutlineHeart className="icon" size="18" />
-            좋아요
+          <li>
+            <NavLink
+              to="/storage/mylist"
+              className={isMyListClicked ? "selected-list" : "list"}
+              onClick={() => {
+                setIsMyListClicked(true);
+                setIsLikedClicked(false);
+                setIsMostListenClicked(false);
+                setIsRecentlyListenClicked(false);
+              }}
+            >
+              내 리스트
+            </NavLink>
           </li>
-          <li className={"list"}>많이 들은 곡</li>
-          <li className={"list"}>최근 감상</li>
+          <li>
+            <NavLink
+              to="/storage/liketrack"
+              className={isLikedClicked ? "selected-list" : "list"}
+              onClick={() => {
+                setIsMyListClicked(false);
+                setIsLikedClicked(true);
+                setIsMostListenClicked(false);
+                setIsRecentlyListenClicked(false);
+              }}
+            >
+              <HiOutlineHeart className="icon" size="18" />
+              좋아요
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/storage/mostlisten"
+              className={isMostListenClicked ? "selected-list" : "list"}
+              onClick={() => {
+                setIsMyListClicked(false);
+                setIsLikedClicked(false);
+                setIsMostListenClicked(true);
+                setIsRecentlyListenClicked(false);
+              }}
+            >
+              많이 들은 곡
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/storage/recentlylisten"
+              className={isRecentlyListenClicked ? "selected-list" : "list"}
+              onClick={() => {
+                setIsMyListClicked(false);
+                setIsLikedClicked(false);
+                setIsMostListenClicked(false);
+                setIsRecentlyListenClicked(true);
+              }}
+            >
+              최근 감상
+            </NavLink>
+          </li>
         </ul>
         <Outlet />
       </div>

--- a/src/pages/storage/Storage.js
+++ b/src/pages/storage/Storage.js
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import { useState, useEffect } from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import { HiOutlineHeart, HiHeart } from "react-icons/hi"; // player like
+
+const StyledStorage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 150px;
+  font-family: "NanumBarunGothic", sans-serif;
+
+  .menu-list {
+    display: flex;
+    align-items: center;
+    border-bottom: 1.5px solid #eeeeee;
+
+    .list {
+      display: flex;
+      align-items: center;
+      padding: 10px;
+
+      .icon {
+        margin-right: 3px;
+      }
+    }
+  }
+`;
+
+const Storage = () => {
+  return (
+    <StyledStorage>
+      <div className="storage-inner-box">
+        <ul className="menu-list">
+          <li className={"list"}>내 리스트</li>
+          <li className={"list"}>
+            <HiOutlineHeart className="icon" size="18" />
+            좋아요
+          </li>
+          <li className={"list"}>많이 들은 곡</li>
+          <li className={"list"}>최근 감상</li>
+        </ul>
+        <Outlet />
+      </div>
+    </StyledStorage>
+  );
+};
+
+export default Storage;

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -1,6 +1,7 @@
 * {
   box-sizing: border-box;
 }
+
 .hidden {
   position: relative;
   top: -999999999999px;
@@ -14,14 +15,14 @@ input::-webkit-inner-spin-button {
 }
 
 @font-face {
-  font-family: 'NanumBarunGothic';
+  font-family: "NanumBarunGothic";
   font-style: normal;
   font-weight: 400;
-  src: url('//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot');
-  src: url('//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot?#iefix')
-      format('embedded-opentype'),
-    url('//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.woff')
-      format('woff'),
-    url('//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.ttf')
-      format('truetype');
+  src: url("//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot");
+  src: url("//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.eot?#iefix")
+      format("embedded-opentype"),
+    url("//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.woff")
+      format("woff"),
+    url("//cdn.jsdelivr.net/font-nanumlight/1.0/NanumBarunGothicWeb.ttf")
+      format("truetype");
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 플레이리스트를 현재 재생목록으로 가져오기 및 CRUD가 전부 가능한 보관함 페이지 만들기

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
**1. 보관함 UI 구현**

중첩 라우팅과 useState를 통해 내 리스트, 좋아요, 많이 들은 곡, 최근감상 페이지를 구현하였고, 내 리스트 UI를 구현하였다.

**2. 플레이리스트 통째로 현재 재생목록에 중복되지 않는 곡 추가하기 구현**

플레이리스트 재생을 눌렀을 때, 현재 재생목록에 중복되지 않는 곡만 담기도록 로직을 구현했다.

**3. shuffle 로직 수정**
셔플을 눌러서 현재 재생목록을 재배열해도 확률상 그대로 유지되는 경우가 있었는데, 그를 방지하는 로직을 구현했다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 중복되지 않는 곡들만 플레이 리스트에 추가, 무조건 가능한 셔플 구현 등 다양한 로직을 짜면서 성장할 수 있었던 것 같다.
- 중첩 라우팅에 익숙해질 수 있었다.

<br />

## :: 기타 질문 및 특이 사항
- 없음
